### PR TITLE
Add passing async tests

### DIFF
--- a/src/test/scala/org/coroutines/ast-canonicalization-tests.scala
+++ b/src/test/scala/org/coroutines/ast-canonicalization-tests.scala
@@ -91,6 +91,8 @@ class ASTCanonicalizationTest extends FunSuite with Matchers {
     val c = call(unit())
     assert(!c.resume)
     assert(!c.isLive)
+    c.result
+    assert(!c.hasException)
   }
 
   test("coroutine should be callable outside value declaration") {

--- a/src/test/scala/org/coroutines/ast-canonicalization-tests.scala
+++ b/src/test/scala/org/coroutines/ast-canonicalization-tests.scala
@@ -90,7 +90,6 @@ class ASTCanonicalizationTest extends FunSuite with Matchers {
 
     val c = call(unit())
     assert(!c.resume)
-    assert(c.result == (()))
     assert(!c.isLive)
   }
 

--- a/src/test/scala/org/coroutines/async-await-tests.scala
+++ b/src/test/scala/org/coroutines/async-await-tests.scala
@@ -1,0 +1,75 @@
+package org.coroutines
+
+
+
+import org.scalatest._
+import scala.annotation.unchecked.uncheckedVariance
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+
+object AsyncAwaitTest {
+  class Cell[+T] {
+    var x: T @uncheckedVariance = _
+  }
+
+  def await[R]: Future[R] ~~> ((Future[R], Cell[R]), R) =
+    coroutine { (f: Future[R]) =>
+      val cell = new Cell[R]
+      yieldval((f, cell))
+      cell.x
+    }
+
+  def async[Y, R](body: ~~~>[(Future[Y], Cell[Y]), R]): Future[R] = {
+    val c = call(body())
+    val p = Promise[R]
+    def loop() {
+      if (!c.resume) p.success(c.result)
+      else {
+        val (future, cell) = c.value
+        for (x <- future) {
+          cell.x = x
+          loop()
+        }
+      }
+    }
+    Future { loop() }
+    p.future
+  }
+
+  object ToughTypeObject {
+    class Inner
+
+    def m2 = async(coroutine { () =>
+      val y = await { Future[List[_]] { Nil } }
+      val z = await { Future[Inner] { new Inner } }
+      (y, z)
+    })
+  }
+}
+
+
+class AsyncAwaitTest extends FunSuite with Matchers {
+  // Source: https://git.io/vrHtj
+  test("propagates tough types") {
+    val fut = org.coroutines.AsyncAwaitTest.ToughTypeObject.m2
+    val res: (List[_], org.coroutines.AsyncAwaitTest.ToughTypeObject.Inner) =
+      Await.result(fut, 2 seconds)
+    assert(res._1 == Nil)
+  }
+
+  // Source: https://git.io/vrHmG
+  // NOTE: Currently fails compilation
+  test("pattern matching partial function") {
+    val c = AsyncAwaitTest.async(coroutine { () =>
+      AsyncAwaitTest.await { Future { 1 } }
+      val a = AsyncAwaitTest.await { Future { 1 } }
+      val f = { case x => x + a }: PartialFunction[Int, Int]
+      AsyncAwaitTest.await { Future { f(2) } }
+    })
+    val res = Await.result(c, 2 seconds)
+    assert(res == 3)
+  }
+}

--- a/src/test/scala/org/coroutines/async-await-tests.scala
+++ b/src/test/scala/org/coroutines/async-await-tests.scala
@@ -3,11 +3,11 @@ package org.coroutines
 
 
 import org.scalatest._
-import scala.language.{ reflectiveCalls, postfixOps }
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.{ reflectiveCalls, postfixOps }
 import scala.util.Success
 
 
@@ -15,6 +15,16 @@ import scala.util.Success
 object AsyncAwaitTest {
   class Cell[+T] {
     var x: T @uncheckedVariance = _
+  }
+
+  object ToughTypeObject {
+    class Inner
+
+    def m2 = async(coroutine { () =>
+      val y = await { Future[List[_]] { Nil } }
+      val z = await { Future[Inner] { new Inner } }
+      (y, z)
+    })
   }
 
   // Doubly defined for ToughTypeObject
@@ -41,16 +51,6 @@ object AsyncAwaitTest {
     }
     Future { loop() }
     p.future
-  }
-
-  object ToughTypeObject {
-    class Inner
-
-    def m2 = async(coroutine { () =>
-      val y = await { Future[List[_]] { Nil } }
-      val z = await { Future[Inner] { new Inner } }
-      (y, z)
-    })
   }
 }
 

--- a/src/test/scala/org/coroutines/async-await-tests.scala
+++ b/src/test/scala/org/coroutines/async-await-tests.scala
@@ -102,36 +102,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     assert(result._1 == Nil)
   }
 
-  // Source: https://git.io/vrHmG
-  /** NOTE: Currently fails compilation.
-  test("pattern matching partial function") {
-    val c = async(coroutine { () =>
-      await(Future(1))
-      val a = await(Future(1))
-      val f = { case x => x + a }: PartialFunction[Int, Int]
-      await(Future(f(2)))
-    })
-    val res = Await.result(c, 2 seconds)
-    assert(res == 3)
-  }
-  */
-
-  // Source: https://git.io/vr79k
-  /** NOTE: Currently fails compilation.
-  test("pattern matching partial function nested") {
-    val c = AsyncAwaitTest.async(coroutine { () =>
-      AsyncAwaitTest.await(Future(1))
-      val neg1 = -1
-      val a = AsyncAwaitTest.await(Future(1))
-      val f = {case x => ({case x => neg1 * x}:
-          PartialFunction[Int, Int])(x + a)}: PartialFunction[Int, Int]
-      AsyncAwaitTest.await(Future(f(2)))
-    })
-    val res = Await.result(c, 2 seconds)
-    assert(res == -3)
-  }
-  */
-
   // Source: https://git.io/vr7H9
   test("pattern matching function") {
     val c = async(coroutine { () =>
@@ -173,37 +143,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     })
   }
 
-  // Source: https://git.io/vr7FE
-  /** NOTE: Currently fails compilation.
-  test("singleton type") {
-    class A { class B }
-    AsyncAwaitTest.async(coroutine { () =>
-      val a = new A
-      def foo(b: a.B) = 0
-      AsyncAwaitTest.await(Future(foo(new a.B)))
-    })
-  }
-  */
-  
-
-  // Source: https://git.io/vr7F6
-  /** NOTE: Currently fails compilation.
-  test("existential match") {
-    trait Container[+A]
-    case class ContainerImpl[A](value: A) extends Container[A]
-    def foo: Future[Container[_]] = AsyncAwaitTest.async(coroutine { () =>
-      val a: Any = List(1)
-      a match {
-        case buf: Seq[_] =>
-          val foo = AsyncAwaitTest.await(Future(5))
-          val e0 = buf(0)
-          ContainerImpl(e0)
-      }
-    })
-    foo
-  }
-  */
-
   // Source: https://git.io/vr7Fx
   test("existential if/else") {
     trait Container[+A]
@@ -219,39 +158,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     })
     foo
   }
-
-  // Source: https://git.io/vr7bJ
-  /** NOTE: Currently fails compilation
-  test("nested method with inconsistency") {
-    import language.{reflectiveCalls, postfixOps}
-
-    class Foo[A]
-
-    object Bippy {
-
-      import ExecutionContext.Implicits.global
-
-      def bar(f: => Unit): Unit = f
-
-      def quux: Future[String] = ???
-
-      def foo = AsyncAwaitTest.async(coroutine { () =>
-        def r[A](m: Foo[A])(n: A) = {
-          bar {
-            locally(m)
-            locally(n)
-            identity[A] _
-          }
-        }
-
-        AsyncAwaitTest.await(quux)
-
-        r(new Foo[String])("")
-      })
-    }
-    Bippy
-  }
-  */
 
   // Source: https://git.io/vr7ba
   test("ticket 63 in scala/async") {
@@ -303,18 +209,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     val inner = Await.result(outer, 5 seconds)
     assert(inner == new IntWrapper("foo"))
   }
-
-  // Source: https://git.io/vr7NJ
-  /** NOTE: This test currently fails compilation.
-  test("ticket 86 in scala/async-- using nested value class") {
-    val f = AsyncAwaitTest.async[Nothing, IntWrapper](coroutine { () =>
-      val a = Future.successful(new IntWrapper("42"))
-      AsyncAwaitTest.await(Future(AsyncAwaitTest.await(a).plusStr))
-    })
-    val res = Await.result(f, 5 seconds)
-    assert(res == "42!")
-  }
-  */
 
   // Source: https://git.io/vr7Nk
   test("ticket 86 in scala/async-- using matched value class") {
@@ -385,54 +279,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     assert(inner == 1)
   }
 
-  // Source: https://git.io/vr7NB
-  /** NOTE: Currently fails compilation
-  test("ticket 106 in scala/async-- value class") {
-    AsyncAwaitTest.async(coroutine { () =>
-      "whatever value" match {
-        case _ =>
-          AsyncAwaitTest.await(Future("whatever return type"))
-          new IntWrapper("value case matters")
-      }
-      "whatever return type"
-    })
-  }
-  */
-  
-
-  // Source: https://git.io/vrFQt
-  /** NOTE: Currently fails compilation.
-  test("Inlining block does not produce duplicate definition") {
-    AsyncAwaitTest.async(coroutine { () =>
-      val f = 12
-      val x = AsyncAwaitTest.await(Future(f))
-      {
-        type X = Int
-        val x: X = 42
-        println(x)
-      }
-      type X = Int
-      x: X
-    })
-  }
-  */
-
-  // Source: https://git.io/vrF5X
-  /** NOTE: Currently fails compilation.
-  test("Inlining block in tail position does not produce duplication definition") {
-    val c = AsyncAwaitTest.async(coroutine { () =>
-      val f = 12
-      val x = AsyncAwaitTest.await(Future(f))
-      {
-        val x = 42
-        x
-      }
-    })
-    val res = Await.result(c, 5 seconds)
-    assert(res == 42)
-  }
-  */
-
   // Source: https://git.io/vrFp5
   test("match as expression 1") {
     val c = AsyncAwaitTest.async(coroutine { () =>
@@ -480,153 +326,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     assert(result == true)
   }
 
-  // Source: https://git.io/vrAWm
-  // NOTE: Currently fails compilation
-  /**
-  test("nested await in if") {
-    val c: Future[Any] = async(coroutine { () =>
-      if ("".isEmpty) {
-        await(Future(await(Future("")).isEmpty))
-      } else 0
-    })
-    assert(Await.result(c, 5 seconds) == true)
-  }
-  */
-
-  // Source: https://git.io/vrAlJ
-  /** NOTE: This test currently fails because the future times out. 
-   *  Interestingly, the future doesn't time out if `1` is passed as the first
-   *  argument to `foo`. 
-   */
-  test("by-name expressions aren't lifted") {
-    def foo(ignored: => Any, b: Int) = b
-    val c = async(coroutine { () =>
-      await(Future(foo(???, await(Future(1)))))
-    })
-    val result = Await.result(c, 5 seconds)
-    assert(result == 1)
-  }
-
-  // Source: https://git.io/vrA0Q
-  /** NOTE: Currently fails compilation. If I remove the parentheses after 
-   * `next`, but keep the ones after the calls to `next` on the line
-   * `foo(next(), await(Future(next())))`,
-   *  then there the compiler is able to find `next` and there is no macro
-   *  expansion error. However, there is the expected compilation error saying
-   *  that "`Int` does not take parameters."
-   *  Removing the parentheses to make the line as such:
-   *  `foo(next, await(Future(next)))`
-   *  creates another macro expansion error.
-  test("evaluation order respected") {
-    def foo(a: Int, b: Int) = (a, b)
-    val c = async(coroutine { () =>
-      var i = 0
-      def next(): Int = {
-        i += 1
-        i
-      }
-      foo(next(), await(Future(next())))
-    })
-    val result = Await.result(c, 5 seconds)
-    assert(result == 1)
-  }
-  */
-
-  // Source: https://git.io/vrAuv
-  /** NOTE: Currently fails compilation. As in the previous test, `get` cannot
-   be found.*/
-  /**
-  test("await in non-primary param section 1") {
-    def foo(a0: Int)(b0: Int) = s"a0 = $a0, b0 = $b0"
-    val c = async(coroutine {() =>
-      var i = 0
-      def get = { i += 1; i }
-      foo(get)(await(Future(get)))
-    })
-    assert(Await.result(c, 5 seconds) == "a0 = 1, b0 = 2")
-  }
-  */
-
-  // Source: https://git.io/vrAzt
-  /** NOTE: All of these tests currently fail compilation because of errors about
-   *  the yield types of the coroutines. The compiler expects the yield type of
-   *  the coroutines `nilAsync` and `c` to be `(Future[?], Cell[?])`, but they
-   *  are both `Nothing`. This does not work because the yield type is invariant.
-   *  I'm not sure why compilation fails here but it succeeds above.
-  test("await in non-primary param section 2") {
-    def foo[T](a0: Int)(b0: Int*) = s"a0 = $a0, b0 = ${b0.head}"
-
-    val c = async(coroutine { () =>
-      var i = 0
-      def get = async(coroutine { () =>
-        i += 1
-        i
-      })
-      val nilAsync = async(coroutine { () =>
-        Nil
-      })
-      foo[Int](await(get))(await(get) ::
-        await(nilAsync) : _*)
-    })
-    assert(Await.result(c, 5 seconds) == "a0 = 1, b0 = 2")
-  }
-
-  // Source: https://git.io/vrpP8
-  test("await in non-primary param section with lazy 1") {
-    def foo[T](a: => Int)(b: Int) = b
-    val c = async(coroutine { () =>
-      def get = async(coroutine { () => 0 } )
-      foo[Int](???)(await(get))
-    })
-    assert(Await.result(c, 5 seconds) == 0)
-  }
-
-  // Source: https://git.io/vrpPN
-  test("await in non-primary param section with lazy 2") {
-    def foo[T](a: Int)(b: => Int) = a
-    val c = async(coroutine { () =>
-      def get = async(coroutine { () => 0 } )
-      foo[Int](await(get))(???)
-    })
-    assert(Await.result(c, 5 seconds) == 0)
-  }
-
-  // Source: https://git.io/vrpXL
-  test("await with lazy") {
-    def foo[T](a: Int, b: => Int) = a
-    val c = async(coroutine { () =>
-      def get = async(coroutine { () => 0 } )
-      foo[Int](await(get), ???)
-    })
-    assert(Await.result(c, 5 seconds) == 0)
-  }
-
-  // Source: https://git.io/vrpXz
-  test("await ok in receiver") {
-    class Foo { def bar(a: Int)(b: Int) = a + b }
-    async(coroutine { () =>
-      await(async(coroutine { () => new Foo })).bar(1)(2)
-    })
-  }
-   */
-
-  // Source: https://git.io/vrhUF
-  /** NOTE: Currently fails compilation because functions cannot be defined
-   *  inside coroutines.
-  test("named arguments respect evaluation order") {
-    def foo(a: Int, b: Int) = (a, b)
-    val c = async(coroutine { () =>
-      var i = 0
-      def next() = {
-        i += 1;
-        i
-      }
-      foo(b = next(), a = await(Future(next())))
-    })
-    assert(Await.result(c, 5 seconds) == (2, 1))
-  }
-   */
-
   // Source: https://git.io/vrhTe
   test("named and default arguments respect evaluation order") {
     var i = 0
@@ -668,22 +367,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     assert(Await.result(c, 5 seconds) == List(1, 2, 3))
   }
 
-  // Source: https://git.io/vrhTc
-  /** NOTE: This test currently fails compilation because of typing issues.
-   *  Also note that `thrower` is declared outside of the line that throws the
-   *  exception because "coroutine blueprints can only be invoked directly
-   *  inside the coroutine."
-  test("await in throw") {
-    val thrower = await(Future(0))
-    val e = intercept[Exception] {
-      async(coroutine { () =>
-        throw new Exception("msg: " + thrower)
-      })
-    }
-    assert(e.getMessage == "msg: 0")
-  }
-   */
-
   // Source: https://git.io/vrhT0
   test("await in typed") {
     val c = async(coroutine { () =>
@@ -714,70 +397,4 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     })
     assert(Await.result(sign, 5 seconds) == 1.0)
   }
-
-  // Source: https://git.io/vrhT6
-  /** NOTE: Currently fails compilation because I haven't found the right
-   *  imports.
-  test("await in implicit apply") {
-    val tb = mkToolbox(s"-cp ${toolboxClasspath}")
-    val tree = tb.typeCheck(tb.parse {
-      """
-        | import scala.language.implicitConversions
-        | implicit def view(a: Int): String = ""
-        | async(coroutine { () =>
-        |   await(Future(0)).length
-        | })
-      """.stripMargin
-    })
-    val applyImplicitView = tree.collect {
-      case x if x.getClass.getName.endsWith("ApplyImplicitView") => x
-    }
-    applyImplicitView.map(_.toString) mustStartWith List("view(a$macro$")
-  }
-   */
-
-  // Source: https://git.io/vrhTD
-  /** NOTE: Compilation currently fails. The block is typed as Unit, I believe.
-  test("nothing typed if") {
-    val result = scala.util.Try(async(coroutine { () =>
-      if (true) {
-        val n = await(Future(1))
-        if (n < 2) {
-          throw new RuntimeException("case a")
-        }
-        else {
-          throw new RuntimeException("case b")
-        }
-      }
-      else {
-        "case c"
-      }
-    }))
-    assert(result.asInstanceOf[scala.util.Failure[_]].exception.getMessage ==
-      "case a")
-  }
-  */
-
-  // Source: https://git.io/vrhTS
-  /** NOTE: Currently fails compilation because of type errors.
-  test("nothing typed match") {
-    val result = scala.util.Try(async(coroutine { () =>
-      0 match {
-        case _ if "".isEmpty =>
-          val n = await(Future(1))
-          n match {
-            case _ if n < 2 =>
-              throw new RuntimeException("case a")
-            case _ =>
-              throw new RuntimeException("case b")
-          }
-        case _ =>
-          "case c"
-      }
-    }))
-
-    assert(result.asInstanceOf[scala.util.Failure[_]].exception.getMessage ==
-      "case a")
-  }
-   */
 }

--- a/src/test/scala/org/coroutines/async-await-tests.scala
+++ b/src/test/scala/org/coroutines/async-await-tests.scala
@@ -230,7 +230,6 @@ class AsyncAwaitTest extends FunSuite with Matchers {
   }
 
   // Source: https://git.io/vr7NZ
-  // NOTE: Need to look at this test's implementation. Might be done incorrectly.
   test("ticket 86 in scala/async-- using matched parameterized value class") {
     def doAThing(param: ParamWrapper[String]) = Future(None)
 

--- a/src/test/scala/org/coroutines/async-await-tests.scala
+++ b/src/test/scala/org/coroutines/async-await-tests.scala
@@ -179,7 +179,8 @@ class AsyncAwaitTest extends FunSuite with Matchers {
           def method(w: W, l: List[S]) = AsyncAwaitTest.async(coroutine { () =>
             val it = l.iterator
             while (it.hasNext) {
-              AsyncAwaitTest.await(Future(funDep.method(w, it.next()))(SomeExecutionContext))
+              AsyncAwaitTest.await(Future(funDep.method(w, it.next()))
+                (SomeExecutionContext))
             }
             w
           })

--- a/src/test/scala/org/coroutines/async-await-tests.scala
+++ b/src/test/scala/org/coroutines/async-await-tests.scala
@@ -1,6 +1,7 @@
 package org.coroutines
 
 
+
 import org.scalatest._
 import scala.language.{ reflectiveCalls, postfixOps }
 import scala.annotation.unchecked.uncheckedVariance
@@ -8,6 +9,7 @@ import scala.concurrent._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Success
+
 
 
 object AsyncAwaitTest {
@@ -54,18 +56,18 @@ object AsyncAwaitTest {
 
 
 class IntWrapper(val value: String) extends AnyVal {
-  def plusStr(): IntWrapper = new IntWrapper(value + "!")
+  def plusStr = Future.successful(value + "!")
 }
 
 
-class ParamWrapper[T](val value: T) extends AnyVal 
+class ParamWrapper[T](val value: T) extends AnyVal
 
 
-private class PrivateWrapper(val value: String) extends AnyVal
+class PrivateWrapper private (private val value: String) extends AnyVal
 
 
-private object PrivateWrapper {
-  def Instance() = new PrivateWrapper("Thugga")
+object PrivateWrapper {
+  def Instance = new PrivateWrapper("")
 }
 
 

--- a/src/test/scala/org/coroutines/async-await-tests.scala
+++ b/src/test/scala/org/coroutines/async-await-tests.scala
@@ -1,7 +1,6 @@
 package org.coroutines
 
 
-
 import org.scalatest._
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent._
@@ -51,6 +50,9 @@ object AsyncAwaitTest {
 }
 
 
+class IntWrapper(val value: String) extends AnyVal
+
+
 class AsyncAwaitTest extends FunSuite with Matchers {
   // Source: https://git.io/vrHtj
   test("propagates tough types") {
@@ -62,14 +64,285 @@ class AsyncAwaitTest extends FunSuite with Matchers {
 
   // Source: https://git.io/vrHmG
   // NOTE: Currently fails compilation
+  /*
   test("pattern matching partial function") {
     val c = AsyncAwaitTest.async(coroutine { () =>
-      AsyncAwaitTest.await { Future { 1 } }
-      val a = AsyncAwaitTest.await { Future { 1 } }
+      AsyncAwaitTest.await(Future(1))
+      val a = AsyncAwaitTest.await(Future(1))
       val f = { case x => x + a }: PartialFunction[Int, Int]
-      AsyncAwaitTest.await { Future { f(2) } }
+      AsyncAwaitTest.await(Future(f(2)))
     })
     val res = Await.result(c, 2 seconds)
     assert(res == 3)
   }
+  */
+
+  // Source: https://git.io/vr79k
+  // NOTE: Currently fails compilation
+  /*
+  test("pattern matching partial function nested") {
+    val c = AsyncAwaitTest.async(coroutine { () =>
+      AsyncAwaitTest.await(Future(1))
+      val neg1 = -1
+      val a = AsyncAwaitTest.await(Future(1))
+      val f = {case x => ({case x => neg1 * x}:
+          PartialFunction[Int, Int])(x + a)}: PartialFunction[Int, Int]
+      AsyncAwaitTest.await(Future(f(2)))
+    })
+    val res = Await.result(c, 2 seconds)
+    assert(res == -3)
+  }
+  */
+
+  // Source: https://git.io/vr7H9
+  test("pattern matching function") {
+    val c = AsyncAwaitTest.async(coroutine { () =>
+      AsyncAwaitTest.await(Future(1))
+      val a = AsyncAwaitTest.await(Future(1))
+      val f = { case x => x + a }: Function[Int, Int]
+      AsyncAwaitTest.await(Future(f(2)))
+    })
+    val res = Await.result(c, 2 seconds)
+    assert(res == 3)
+  }
+
+  // Source: https://git.io/vr7HA
+  test("existential bind 1") {
+    def m(a: Any) = AsyncAwaitTest.async(coroutine { () =>
+      a match {
+        case s: Seq[_] =>
+          val x = s.size
+          var ss = s
+          ss = s
+          AsyncAwaitTest.await(Future(x))
+      }
+    })
+    val res = Await.result(m(Nil), 2 seconds)
+    assert(res == 0)
+  }
+
+  // Source: https://git.io/vr7Qm
+  test("existential bind 2") {
+    def conjure[T]: T = null.asInstanceOf[T]
+
+    def m1 = AsyncAwaitTest.async(coroutine { () =>
+      val p: List[Option[_]] = conjure[List[Option[_]]]
+      AsyncAwaitTest.await(Future(1))
+    })
+
+    def m2 = AsyncAwaitTest.async(coroutine { () =>
+      AsyncAwaitTest.await(Future[List[_]](Nil))
+    })
+  }
+
+  // Source: https://git.io/vr7FE
+  // NOTE: Currently fails compilation
+  /**
+  test("singleton type") {
+    class A { class B }
+    AsyncAwaitTest.async(coroutine { () =>
+      val a = new A
+      def foo(b: a.B) = 0
+      AsyncAwaitTest.await(Future(foo(new a.B)))
+    })
+  }
+  */
+  
+
+  // Source: https://git.io/vr7F6
+  // NOTE: Currently fails compilation
+  /**
+  test("existential match") {
+    trait Container[+A]
+    case class ContainerImpl[A](value: A) extends Container[A]
+    def foo: Future[Container[_]] = AsyncAwaitTest.async(coroutine { () =>
+      val a: Any = List(1)
+      a match {
+        case buf: Seq[_] =>
+          val foo = AsyncAwaitTest.await(Future(5))
+          val e0 = buf(0)
+          ContainerImpl(e0)
+      }
+    })
+    foo
+  }
+  */
+
+  // Source: https://git.io/vr7Fx
+  test("existential if/else") {
+    trait Container[+A]
+    case class ContainerImpl[A](value: A) extends Container[A]
+    def foo: Future[Container[_]] = AsyncAwaitTest.async(coroutine { () =>
+      val a: Any = List(1)
+      if (true) {
+        val buf: Seq[_] = List(1)
+        val foo = AsyncAwaitTest.await(Future(5))
+        val e0 = buf(0)
+        ContainerImpl(e0)
+      } else ???
+    })
+    foo
+  }
+
+  // Source: https://git.io/vr7bJ
+  // NOTE: Currently fails compilation
+  /**
+  test("nested method with inconsistency") {
+    import language.{reflectiveCalls, postfixOps}
+
+    class Foo[A]
+
+    object Bippy {
+
+      import ExecutionContext.Implicits.global
+
+      def bar(f: => Unit): Unit = f
+
+      def quux: Future[String] = ???
+
+      def foo = AsyncAwaitTest.async(coroutine { () =>
+        def r[A](m: Foo[A])(n: A) = {
+          bar {
+            locally(m)
+            locally(n)
+            identity[A] _
+          }
+        }
+
+        AsyncAwaitTest.await(quux)
+
+        r(new Foo[String])("")
+      })
+    }
+    Bippy
+  }
+  */
+
+  // Source: https://git.io/vr7ba
+  test("ticket 63 in scala/async") {
+    object SomeExecutionContext extends ExecutionContext {
+      def reportFailure(t: Throwable): Unit = ???
+      def execute(runnable: Runnable): Unit = ???
+    }
+
+    trait FunDep[W, S, R] {
+      def method(w: W, s: S): Future[R]
+    }
+
+    object FunDep {
+      implicit def `Something to do with List`[W, S, R]
+        (implicit funDep: FunDep[W, S, R]) =
+        new FunDep[W, List[S], W] {
+          def method(w: W, l: List[S]) = AsyncAwaitTest.async(coroutine { () =>
+            val it = l.iterator
+            while (it.hasNext) {
+              AsyncAwaitTest.await(Future(funDep.method(w, it.next()))(SomeExecutionContext))
+            }
+            w
+          })
+        }
+    }
+  }
+
+  // Source: https://git.io/vr7bX
+  test("ticket 66 in scala/async") {
+    val e = new Exception()
+    val f: Future[Nothing] = Future.failed(e)
+    val f1 = AsyncAwaitTest.async(coroutine { () =>
+      AsyncAwaitTest.await(Future(f))
+    })
+    try {
+      Await.result(f1, 5.seconds)
+    } catch {
+      case `e` =>
+    }
+  }
+
+  // Source: https://git.io/vr7Nf
+  /** NOTE: Ignoring this test until I find the correct implementation of
+    * `IntWrapper`.
+  test("ticket 83 in scala/async-- using value class") {
+    val f = AsyncAwaitTest.async(coroutine { () =>
+      val uid = new IntWrapper("foo")
+      AsyncAwaitTest.await(Future(Future(uid)))
+    })
+    val outer = Await.result(f, 5.seconds)
+    val inner = Await.result(outer, 5 seconds)
+    assert(inner == new IntWrapper("foo"))
+  }
+  */
+
+
+  // Source: https://git.io/vr7NJ
+  /** NOTE: Ignoring this test until I find the correct implementation of
+    * `IntWrapper`.
+  test("ticket 86 in scala/async-- using nested value class") {
+    val f = AsyncAwaitTest.async(coroutine { () =>
+      val a = Future.successful(new IntWrapper("42"))
+      AsyncAwaitTest.await(AsyncAwaitTest.await(a).plusStr)
+    })
+    val outer = Await.result(f, 5 seconds)
+    val inner = Await.result(outer, 5 seconds)
+    assert(inner == "42!")
+  }
+  */
+
+  // Source: https://git.io/vr7Nk
+  /** NOTE: Ignoring this test until I find the correct implementation of
+    * `IntWrapper`.
+  test("ticket 86 in scala/async-- using matched value class") {
+    def doAThing(param: IntWrapper) = Future(None)
+
+    val fut = AsyncAwaitTest.async(coroutine { () =>
+      Option(new IntWrapper("value!")) match {
+        case Some(valueHolder) =>
+          AsyncAwaitTest.await(Future(doAThing(valueHolder)))
+        case None =>
+          None
+      }
+    })
+
+    val result = Await.result(fut, 5.seconds)
+    result mustBe None
+  }
+  */
+
+  // Source: https://git.io/vr7NZ
+  /** NOTE: Ignoring this test until I find the correct implementation of
+    * `ParamWrapper`.
+  test("ticket 86 in scala/async-- using matched parameterized value class") {
+  }
+  */
+
+  // Source: https://git.io/vr7NW
+  /** NOTE: Ignoring this test until I find the correct implementation of
+    * `ParamWrapper`.
+  test("ticket 86 in scala/async-- using private value class") {
+
+  }
+  */
+
+  // Source: https://git.io/vr7N8
+  test("await of abstract type") {
+    def combine[A](a1: A, a2: A): A = a1
+
+    def combineAsync[A](a1: Future[A], a2: Future[A]) =
+      AsyncAwaitTest.async(coroutine { () =>
+        combine(AsyncAwaitTest.await(Future(a1)), AsyncAwaitTest.await(Future(a2)))
+      })
+
+    val fut = combineAsync(Future(1), Future(2))
+
+    val outer = Await.result(fut, 5 seconds)
+    val inner = Await.result(outer, 5 seconds)
+    assert(inner == 1)
+  }
+
+  // Source: https://git.io/vr7NB
+  /** NOTE: Ignoring this test until I find the correct implementation of
+    * `IntWrapper`.
+  test("ticket 106 in scala/async-- value class") {
+
+  }
+  */
 }

--- a/src/test/scala/org/coroutines/coroutine-tests.scala
+++ b/src/test/scala/org/coroutines/coroutine-tests.scala
@@ -85,7 +85,6 @@ class CoroutineTest extends FunSuite with Matchers {
     assert(c.resume)
     assert(c.value == List("5"))
     assert(!c.resume)
-    assert(c.result == (()))
   }
 
   test("should lub yieldtos and returns") {
@@ -345,7 +344,6 @@ class CoroutineTest extends FunSuite with Matchers {
       assert(c.value == -i)
     }
     assert(!c.resume)
-    assert(c.result == (()))
   }
 
   test("an anonymous coroutine should be applied") {

--- a/src/test/scala/org/coroutines/coroutine-tests.scala
+++ b/src/test/scala/org/coroutines/coroutine-tests.scala
@@ -85,6 +85,8 @@ class CoroutineTest extends FunSuite with Matchers {
     assert(c.resume)
     assert(c.value == List("5"))
     assert(!c.resume)
+    c.result
+    assert(!c.hasException)
   }
 
   test("should lub yieldtos and returns") {
@@ -117,6 +119,8 @@ class CoroutineTest extends FunSuite with Matchers {
     assert(c1.value == 5)
     assert(!c1.resume)
     assert(c1.isCompleted)
+    c1.result
+    assert(!c1.hasException)
     val c2 = call(xOrY(-2, 7))
     assert(c2.resume)
     assert(c2.value == 7)
@@ -344,6 +348,8 @@ class CoroutineTest extends FunSuite with Matchers {
       assert(c.value == -i)
     }
     assert(!c.resume)
+    c.result
+    assert(!c.hasException)
   }
 
   test("an anonymous coroutine should be applied") {

--- a/src/test/scala/org/coroutines/coroutine-tests.scala
+++ b/src/test/scala/org/coroutines/coroutine-tests.scala
@@ -681,4 +681,32 @@ class WideValueTypesTest extends FunSuite with Matchers {
     assert(c.result == 8.0)
     assert(c.isCompleted)
   }
+
+  test("should be able to define uncalled function inside coroutine") {
+    val oy = coroutine { () =>
+      def foo(): String = "bar"
+      val bar = "bar"
+      1
+    }
+    val c = call(oy())
+    assert(!c.resume)
+    assert(c.hasResult)
+    assert(c.result == 1)
+    assert(c.isCompleted)
+  }
+
+  /** NOTE: Currently fails compilation because the compiler cannot find `foo`.
+  test("should be able to define called function inside coroutine") {
+    val oy = coroutine { () =>
+      def foo(): String = "bar"
+      val bar = foo()
+      1
+    }
+    val c = call(oy())
+    assert(!c.resume)
+    assert(c.hasResult)
+    assert(c.result == 1)
+    assert(c.isCompleted)
+  }
+  */
 }

--- a/src/test/scala/org/coroutines/coroutine-tests.scala
+++ b/src/test/scala/org/coroutines/coroutine-tests.scala
@@ -702,19 +702,4 @@ class WideValueTypesTest extends FunSuite with Matchers {
     assert(c.result == 1)
     assert(c.isCompleted)
   }
-
-  /** NOTE: Currently fails compilation because the compiler cannot find `foo`.
-  test("should be able to define called function inside coroutine") {
-    val oy = coroutine { () =>
-      def foo(): String = "bar"
-      val bar = foo()
-      1
-    }
-    val c = call(oy())
-    assert(!c.resume)
-    assert(c.hasResult)
-    assert(c.result == 1)
-    assert(c.isCompleted)
-  }
-   */
 }

--- a/src/test/scala/org/coroutines/coroutine-tests.scala
+++ b/src/test/scala/org/coroutines/coroutine-tests.scala
@@ -708,5 +708,5 @@ class WideValueTypesTest extends FunSuite with Matchers {
     assert(c.result == 1)
     assert(c.isCompleted)
   }
-  */
+   */
 }

--- a/src/test/scala/org/coroutines/regression-tests.scala
+++ b/src/test/scala/org/coroutines/regression-tests.scala
@@ -21,11 +21,15 @@ class RegressionTest extends FunSuite with Matchers {
     assert(c1.value == 5)
     assert(!c1.resume)
     assert(c1.isCompleted)
+    c1.result
+    assert(!c1.hasException)
     val c2 = call(xOrY(-2, 7))
     assert(c2.resume)
     assert(c2.value == 7)
     assert(!c2.resume)
     assert(c2.isCompleted)
+    c2.result
+    assert(!c2.hasException)
   }
 
   test("coroutine should have a nested if statement") {

--- a/src/test/scala/org/coroutines/regression-tests.scala
+++ b/src/test/scala/org/coroutines/regression-tests.scala
@@ -21,13 +21,11 @@ class RegressionTest extends FunSuite with Matchers {
     assert(c1.value == 5)
     assert(!c1.resume)
     assert(c1.isCompleted)
-    assert(c1.result == (()))
     val c2 = call(xOrY(-2, 7))
     assert(c2.resume)
     assert(c2.value == 7)
     assert(!c2.resume)
     assert(c2.isCompleted)
-    assert(c2.result == (()))
   }
 
   test("coroutine should have a nested if statement") {

--- a/src/test/scala/org/coroutines/try-catch-tests.scala
+++ b/src/test/scala/org/coroutines/try-catch-tests.scala
@@ -20,6 +20,8 @@ class TryCatchTest extends FunSuite with Matchers {
     val c0 = call(rube())
     assert(!c0.resume)
     assert(c0.isCompleted)
+    c0.result
+    assert(!c0.hasException)
   }
 
   test("try-catch-finally block") {

--- a/src/test/scala/org/coroutines/try-catch-tests.scala
+++ b/src/test/scala/org/coroutines/try-catch-tests.scala
@@ -66,6 +66,8 @@ class TryCatchTest extends FunSuite with Matchers {
     assert(!error)
     assert(!completed)
     assert(!c0.resume)
+    c0.result
+    assert(!c0.hasException)
     assert(!runtime)
     assert(error)
     assert(completed)

--- a/src/test/scala/org/coroutines/try-catch-tests.scala
+++ b/src/test/scala/org/coroutines/try-catch-tests.scala
@@ -19,7 +19,6 @@ class TryCatchTest extends FunSuite with Matchers {
 
     val c0 = call(rube())
     assert(!c0.resume)
-    assert(c0.result == (()))
     assert(c0.isCompleted)
   }
 
@@ -65,7 +64,6 @@ class TryCatchTest extends FunSuite with Matchers {
     assert(!error)
     assert(!completed)
     assert(!c0.resume)
-    assert(c0.result == (()))
     assert(!runtime)
     assert(error)
     assert(completed)


### PR DESCRIPTION
- Port a significant number of [Scala Async](https://github.com/scala/async) tests that were mentioned [in this comment](https://github.com/storm-enroute/coroutines/issues/15#issuecomment-173423870). 
- Remove equality checks between `Unit` type values. These checks always return true and generated warnings such as:
```
[warn] /home/jess/projects/coroutines/src/test/scala/org/coroutines/try-catch-tests.scala:68: comparing values of types Unit and Unit using `==' will always yield true
[warn]     assert(c0.result == (()))
```