### PR TITLE
Disallow yields inside async

### DIFF
--- a/coroutines-extra/src/main/scala/org/coroutines/extra/AsyncAwait.scala
+++ b/coroutines-extra/src/main/scala/org/coroutines/extra/AsyncAwait.scala
@@ -76,6 +76,54 @@ object AsyncAwait {
     p.future
   }
 
+  /** Thrown by `NoYieldsValidator` if a value is yielded inside an `async` block.
+   *
+   *  @param position  Where a yield occurred inside an async block.
+   *  @param message   A description of the error.
+   */
+  class YieldInsideAsyncException[P](val position: P, val message: String)
+    extends RuntimeException
+
+  def validate[C <: Context](c: C)(body: c.Tree) {
+    import c.universe._
+
+    /** Ensures that no values are yielded inside the async block.
+     *
+     *  It is similar to and shares functionality with
+     *  [[org.coroutines.AstCanonicalization.NestedContextValidator]].
+     *
+     *  @param typer  Holds the typings for the body of the coroutine. Can be generated
+     *                using `org.coroutines.common.ByTreeTyper`.
+     */
+    class NoYieldsValidator extends Traverser {
+      // return type is the lub of the function return type and yield argument types
+      def isCoroutinesPkg(q: Tree) = q match {
+        case q"org.coroutines.`package`" => true
+        case q"coroutines.this.`package`" => true
+        case t => false
+      }
+
+      override def traverse(tree: Tree): Unit = tree match {
+        case q"$qual.yieldval[$_]($_)" if isCoroutinesPkg(qual) =>
+          throw new YieldInsideAsyncException[c.universe.Position](tree.pos,
+            "The yieldval statement only be invoked directly inside the coroutine. " +
+            "Nested classes, functions or for-comprehensions, should either use the " +
+            "call statement or declare another coroutine.")
+        case q"$qual.yieldto[$_]($_)" if isCoroutinesPkg(qual) =>
+          throw new YieldInsideAsyncException[c.universe.Position](tree.pos,
+            "The yieldto statement only be invoked directly inside the coroutine. " +
+            "Nested classes, functions or for-comprehensions, should either use the " +
+            "call statement or declare another coroutine.")
+        case q"$qual.call($co.apply(..$args))" if isCoroutinesPkg(qual) =>
+          // no need to check further, the call macro will validate the coroutine type
+        case _ =>
+          super.traverse(tree)
+      }
+    }
+
+    new NoYieldsValidator().traverse(body)
+  }
+
   /** Wraps `body` inside a coroutine and asynchronously invokes it using `asyncMacro`.
    *
    *  @param body  The block of code to wrap inside an asynchronous coroutine.
@@ -94,45 +142,13 @@ object AsyncAwait {
   def asyncMacro[Y, R](c: Context)(body: c.Tree): c.Tree = {
     import c.universe._
 
-    /** This class ensrues that no values are yielded inside the async block.
-     *
-     *  It is similar to and shares functionality with
-     *  [[org.coroutines.AstCanonicalization.NestedContextValidator]].
-     *
-     *  @param typer  Holds the typings for the body of the coroutine. Can be generated
-     *                using `org.coroutines.common.ByTreeTyper`.
-     */
-    class NoYieldsValidator(implicit typer: common.ByTreeTyper[c.type])
-    extends Traverser {
-      // return type is the lub of the function return type and yield argument types
-      def isCoroutinesPkg(q: Tree) = q match {
-        case q"org.coroutines.`package`" => true
-        case q"coroutines.this.`package`" => true
-        case t => false
-      }
-
-      override def traverse(tree: Tree): Unit = tree match {
-        case q"$qual.yieldval[$_]($_)" if isCoroutinesPkg(qual) =>
-          c.abort(
-            tree.pos,
-            "The yieldval statement only be invoked directly inside the coroutine. " +
-            "Nested classes, functions or for-comprehensions, should either use the " +
-            "call statement or declare another coroutine.")
-        case q"$qual.yieldto[$_]($_)" if isCoroutinesPkg(qual) =>
-          c.abort(
-            tree.pos,
-            "The yieldto statement only be invoked directly inside the coroutine. " +
-            "Nested classes, functions or for-comprehensions, should either use the " +
-            "call statement or declare another coroutine.")
-        case q"$qual.call($co.apply(..$args))" if isCoroutinesPkg(qual) =>
-          // no need to check further, the call macro will validate the coroutine type
-        case _ =>
-          super.traverse(tree)
-      }
+    try {
+      validate[Context](c)(body)
+    } catch {
+      case te: YieldInsideAsyncException[c.Position] =>
+        c.abort(te.position, te.message)
+      case re: RuntimeException => throw re
     }
-
-    implicit val typer = new common.ByTreeTyper[c.type](c)(body)
-    new NoYieldsValidator().traverse(body)
 
     q"""
        val c = coroutine { () =>

--- a/coroutines-extra/src/main/scala/org/coroutines/extra/AsyncAwait.scala
+++ b/coroutines-extra/src/main/scala/org/coroutines/extra/AsyncAwait.scala
@@ -94,8 +94,14 @@ object AsyncAwait {
   def asyncMacro[Y, R](c: Context)(body: c.Tree): c.Tree = {
     import c.universe._
 
-    // This class shares functionality with `NestedContextValidator`. It ensures that
-    // no values are yielded inside the async block.
+    /** This class ensrues that no values are yielded inside the async block.
+     *
+     *  It is similar to and shares functionality with
+     *  [[org.coroutines.AstCanonicalization.NestedContextValidator]].
+     *
+     *  @param typer  Holds the typings for the body of the coroutine. Can be generated
+     *                using `org.coroutines.common.ByTreeTyper`.
+     */
     class NoYieldsValidator(implicit typer: common.ByTreeTyper[c.type])
     extends Traverser {
       // return type is the lub of the function return type and yield argument types

--- a/coroutines-extra/src/test/scala/org/coroutines/extra/async-await-tests.scala
+++ b/coroutines-extra/src/test/scala/org/coroutines/extra/async-await-tests.scala
@@ -88,14 +88,23 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     assert(exception.getMessage == errorMessage)
   }
 
-  test("error handling test 3") {
-    intercept[AsyncAwait.YieldInsideAsyncException[_]] {
-      val future = AsyncAwait.async {
-        yieldval("hubba")
-        AsyncAwait.await(Future("dog"))
-      }
-      Await.result(future, 1 seconds)
+  test("no yields allowed inside async statements 1") {
+    """val future = AsyncAwait.async {
+      yieldval("hubba")
+      Future(1)
+    }""" shouldNot compile
+  }
+
+  test("no yields allowed inside async statements 2") {
+    val c = coroutine { () =>
+      yieldval(0)
     }
+    val instance = call(c())
+
+    """val future = AsyncAwait.async {
+      yieldto(instance)
+      Future(1)
+    }""" shouldNot compile
   }
 
   /** Source: https://git.io/vowde

--- a/coroutines-extra/src/test/scala/org/coroutines/extra/async-await-tests.scala
+++ b/coroutines-extra/src/test/scala/org/coroutines/extra/async-await-tests.scala
@@ -119,6 +119,16 @@ class AsyncAwaitTest extends FunSuite with Matchers {
     assert(exception.getMessage == errorMessage)
   }
 
+  test("error handling test 3") {
+    intercept[AsyncAwait.YieldInsideAsyncException[_]] {
+      val future = AsyncAwait.async {
+        yieldval("hubba")
+        AsyncAwait.await(Future("dog"))
+      }
+      Await.result(future, 1 seconds)
+    }
+  }
+
   /** Source: https://git.io/vowde
    *  Without the closing `()`, the compiler complains about expecting return
    *  type `Future[Unit]` but finding `Future[Nothing]`.


### PR DESCRIPTION
Closes #26.

Prevents the user from writing `yieldval`, `yieldto` statements inside `async` bodies. This is an abstraction leak.