### PR TITLE
Add, test, and document `Coroutine.getException`

### DIFF
--- a/src/main/scala/org/coroutines/Coroutine.scala
+++ b/src/main/scala/org/coroutines/Coroutine.scala
@@ -247,6 +247,16 @@ object Coroutine {
      */
     final def hasException: Boolean = isCompleted && $exception != null
 
+    /** Returns an `Option` object wrapping the exception thrown by this coroutine.
+     *
+     *  @return If `hasException`, a `Some` instance wrapping the exception thrown by
+     *          this coroutine. Otherwise, `None`.
+     */
+    final def getException: Option[Throwable] = {
+      if (hasException) Some($exception)
+      else None
+    }
+
     /** Returns `false` iff the coroutine instance completed execution.
      *
      *  This is true if there are either more yield statements or if the

--- a/src/test/scala/org/coroutines/coroutine-tests.scala
+++ b/src/test/scala/org/coroutines/coroutine-tests.scala
@@ -706,4 +706,32 @@ class WideValueTypesTest extends FunSuite with Matchers {
     assert(c.result == 1)
     assert(c.isCompleted)
   }
+
+  test("should be able to access thrown exceptions via `getException`") {
+    val failure = coroutine { () =>
+      sys.error("rats!")
+    }
+    val instance = call(failure())
+    assert(!instance.resume)
+    assert(instance.hasException)
+    instance.getException match {
+      case Some(exception) => assert(exception.getMessage() == "rats!")
+      case None => assert(false)
+    }
+  }
+
+  test("`getException` should return `None` when there is no exception") {
+    val simple = coroutine { () =>
+      yieldval(1)
+      2
+    }
+    val instance = call(simple())
+    assert(instance.getException == None)
+    assert(instance.resume)
+    assert(instance.value == 1)
+    assert(instance.getException == None)
+    assert(!instance.resume)
+    assert(instance.result == 2)
+    assert(instance.getException == None)
+  }
 }


### PR DESCRIPTION
Closes #32.

I figured that an `Option` was a better choice than a `Try`. 